### PR TITLE
Resolve #40

### DIFF
--- a/nmap3/nmapparser.py
+++ b/nmap3/nmapparser.py
@@ -200,7 +200,7 @@ class NmapCommandParser(object):
         """
         Parse parts from xml
         """
-        addresses = xml.findall("host/address")
+        addresses = xml.findall("address")
         
         for addr in addresses:
             if(addr.attrib.get("addrtype") == "mac"):


### PR DESCRIPTION
This returns the whole mac address object. The following attributes are returned now:
```
 "macaddress": {
   "addr": "AA:AA:AA:AA:AA:AA",
   "addrtype": "mac",
   "vendor": "Some Vendor"
  }
```
The `addrtype` attribute is useless but the vendor attribute it pretty useful in my opinion. If only the mac address is wanted, the PR can be changed to only return the `addr` value with `.get('addr')` in the return statement of parse_mac_address.